### PR TITLE
use the VSCode API to load the workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ Easily switch between workspaces
 
 When using a `folder/name` path as the workspace's file name, the `folder` directory stucture is automatically created before the workspace file is saved.
 
-## Requirements
-
-* The editor (i.e., `code` or `code-insiders`) must be in your `$PATH`
-  or the path to the appropriate executable must be set through the available settings
-  (`vscodeWorkspaceSwitcher.codeExecutable` or `vscodeWorkspaceSwitcher.codeInsidersExecutable`)
-
 ## Configuration
 
 This extension contributes the following settings:
@@ -34,10 +28,6 @@ This extension contributes the following settings:
 * `vscodeWorkspaceSwitcher.paths`
     * Array of directory globs, representing the directories where your `.code-workspace` files are stored
     * These directory globs will also be used to select where to create a `.code-workspace` file for the current workspace
-* `vscodeWorkspaceSwitcher.codeExecutable`
-    * String representing the path to VS Code's executable in case it cannot be found in `$PATH`
-* `vscodeWorkspaceSwitcher.codeInsidersExecutable`
-    * String representing the path to VS Code Insiders's executable in case it cannot be found in `$PATH`
 * `vscodeWorkspaceSwitcher.showInActivityBar`
     * Boolean controlling whether or not the list of workspaces will be shown in a separate view in the Activity Bar
 * `vscodeWorkspaceSwitcher.showInExplorer`

--- a/package.json
+++ b/package.json
@@ -38,16 +38,6 @@
           "default": [],
           "description": "Paths of directories when `.code-workspace` files can be saved and then read from"
         },
-        "vscodeWorkspaceSwitcher.codeExecutable": {
-          "type": "string",
-          "default": "code",
-          "description": "Path to the executable file for VS Code"
-        },
-        "vscodeWorkspaceSwitcher.codeInsidersExecutable": {
-          "type": "string",
-          "default": "code-insiders",
-          "description": "Path to the executable file for VS Code Insiders"
-        },
         "vscodeWorkspaceSwitcher.showInActivityBar": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,7 +116,7 @@ function saveWorkspacePrompt() {
 
               util.refreshTreeData();
 
-              util.switchToWorkspace(<WorkspaceEntry>{
+              return util.switchToWorkspace(<WorkspaceEntry>{
                 path: workspaceFilePath,
               });
             } catch (error) {
@@ -134,11 +134,11 @@ function saveWorkspacePrompt() {
                     return;
                   }
 
-                  workspaceFilePathSaveFunc();
+                  return workspaceFilePathSaveFunc();
                 },
                 (reason: any) => { });
           } else {
-            workspaceFilePathSaveFunc();
+            return workspaceFilePathSaveFunc();
           }
         },
         (reason: any) => { });
@@ -178,7 +178,7 @@ function switchWorkspacePrompt(inNewWindow: boolean = false) {
         return;
       }
 
-      util.switchToWorkspace(entry, inNewWindow);
+      return util.switchToWorkspace(entry, inNewWindow);
     },
     (reason: any) => { });
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,9 +86,8 @@ export function getFirstWorkspaceFolderName(): string {
 }
 
 export function switchToWorkspace(workspaceEntry: WorkspaceEntry, inNewWindow: boolean = false) {
-  const app = getApp();
-  const command = `${app} ${inNewWindow ? '-n' : '-r'} "${workspaceEntry.path}"`;
-  exec(command, onCommandRun);
+  const uri = vscode.Uri.file(workspaceEntry.path);
+  return vscode.commands.executeCommand('vscode.openFolder', uri, inNewWindow);
 }
 
 export function deleteWorkspace(workspaceEntry: WorkspaceEntry, prompt: boolean) {
@@ -107,31 +106,6 @@ export function deleteWorkspace(workspaceEntry: WorkspaceEntry, prompt: boolean)
         (reason: any) => { });
   } else {
     unlinkSync(workspaceEntry.path);
-  }
-}
-
-export function getApp() {
-  const key = `${vscode.env.appName.toLowerCase().search("insiders") !== -1 ? 'codeInsiders' : 'code'}Executable`;
-  const app = <string>vscode.workspace.getConfiguration('vscodeWorkspaceSwitcher').get(key);
-
-  if (app.search(/\s/) !== -1) {
-    return `"${app}"`;
-  }
-
-  if (app === 'code' && process.platform.toLocaleLowerCase().startsWith("win")) {
-    const codeWindowsScriptPath = join(dirname(process.execPath), 'bin', 'code.cmd');
-
-    if (existsSync(codeWindowsScriptPath) && statSync(codeWindowsScriptPath).isFile()) {
-      return `"${codeWindowsScriptPath}"`;
-    }
-  }
-
-  return app;
-}
-
-export function onCommandRun(err: Error, stdout: string, stderr: string) {
-  if (err || stderr) {
-    vscode.window.showErrorMessage((err || { message: stderr }).message);
   }
 }
 


### PR DESCRIPTION
Launching the VSCode executable to load a new workspace (either in the current window or in a new window) has a lot of shortcomings and no benefit. It could fail in countless ways and the user experience is awful.
It can be done easier, faster and more reliable by using VSCode's API.

This PR refactors the loading of a new workspace (either in the current window or in a new window) by using the [`vscode.openFolder` built-in command](https://code.visualstudio.com/api/references/commands) provided by VSCode.